### PR TITLE
attempting to get autoscroll to start

### DIFF
--- a/script.js
+++ b/script.js
@@ -17,13 +17,12 @@ $(document).ready(function(){
           "speed": "medium",
           "pause": 5,
           "click": true,
-          "minimumMovement": 10
+          "minimumMovement": 5
         });
   },500);
 
   function play() {
     var $scroll = _getScrollEl();
-
     if ($scroll) {
       console.log('play');
       $scroll.play();


### PR DESCRIPTION
@stulees when you have a second could you take a look at this? I am still having issues with getting autoscroll to work, and I am not too sure why.

I have set up a simple demo with an outer #wrapper, a #scroll-container and an inner #content wrapper which contains text in p tags. I have set .autoscroll to the #scroll-container and have run bower-install to get the Greensock dependencies (although in this example I am using the cdnjs. links from the IU example.

It seems to manually scroll, but I can't get the automatic scroll to work - ideally working in the same exact way as the IU president's list. I feel like I am missing something basic, so if you can see where I am going wrong and can point me in the right direction that would be great. Thanks!
